### PR TITLE
back button in epg goes to previous window instead of channel group …

### DIFF
--- a/1080i/Includes_View.xml
+++ b/1080i/Includes_View.xml
@@ -141,7 +141,6 @@
         <control type="epggrid" id="10" description="EPG">
             <onup>11</onup>
             <ondown>11</ondown>
-            <onback>11</onback>
             <viewtype label="19069">list</viewtype>
             <include condition="!Skin.HasSetting(PVRGuide.Info)">View_PVR_Guide_ProgressLine_Full</include>
             <include condition="Skin.HasSetting(PVRGuide.Info)">View_PVR_Guide_ProgressLine_Half</include>
@@ -240,7 +239,6 @@
         <control type="epggrid" id="10" description="EPG">
             <onup>11</onup>
             <ondown>11</ondown>
-            <onback>PreviousWindow</onback>
             <viewtype label="19069">list</viewtype>
             <include condition="!Skin.HasSetting(PVRGuide.Info)">View_PVR_Guide_ProgressLine_Full</include>
             <include condition="Skin.HasSetting(PVRGuide.Info)">View_PVR_Guide_ProgressLine_Half</include>


### PR DESCRIPTION
back button in epg goes to previous window instead of channel group selection. This also preserves focus on current channel when entering epg again