### PR TITLE
Enable notification when busy

### DIFF
--- a/1080i/DialogNotification.xml
+++ b/1080i/DialogNotification.xml
@@ -4,7 +4,6 @@
     <controls>
         <control type="group">
             <visible>!Window.IsVisible(Startup.xml)</visible>
-            <visible>!Window.IsVisible(DialogBusy.xml)</visible>
             <control type="group">
                 <visible>!Window.IsVisible(fullscreenvideo) + !Window.IsVisible(visualisation)</visible>
                 <visible>!Window.IsVisible(Home.xml) | Skin.HasSetting(HomeMulti) | Window.IsVisible(DialogVideoInfo.xml) | Window.IsVisible(DialogMusicInfo.xml) | Window.IsVisible(DialogAddonInfo.xml) | Control.HasFocus(5610) | String.IsEqual(Window(Home).Property(WidgetFocus),5610)</visible>


### PR DESCRIPTION
## Summary
- Notifications (`DialogNotification.xml`) were hidden whenever `DialogBusy.xml` was in the window stack, which stayed active for the full duration of some add-on dialogs (e.g. source-search windows in video add-ons). This made notifications invisible until the busy dialog closed.
- Removed the `!Window.IsVisible(DialogBusy.xml)` visibility condition for the standard notification group, matching Estuary's default behavior (notifications are not suppressed by the busy dialog).

## Test plan
- [x] Confirmed with a plugin that opens a custom dialog while keeping `DialogBusy` active: notification now shows immediately (verified live via JSON-RPC `GUI.ShowNotification`) instead of only after closing the dialog.