### PR TITLE
Fix video type for widget in main menu

### DIFF
--- a/shortcuts/menus.xml
+++ b/shortcuts/menus.xml
@@ -271,7 +271,7 @@
             <label>$LOCALIZE[1037]</label>
             <icon>DefaultFolder.png</icon>
             <property name="widgetPath">addons://sources/video/</property>
-            <property name="widgetType">video</property>
+            <property name="widgetType">videos</property>
             <property name="widgetTarget">videos</property>
             <property name="widgetAspect">SmallSquare</property>
             <property name="widgetSource">addon</property>

--- a/shortcuts/menus.xml
+++ b/shortcuts/menus.xml
@@ -271,8 +271,8 @@
             <label>$LOCALIZE[1037]</label>
             <icon>DefaultFolder.png</icon>
             <property name="widgetPath">addons://sources/video/</property>
-            <property name="widgetType">programs</property>
-            <property name="widgetTarget">programs</property>
+            <property name="widgetType">video</property>
+            <property name="widgetTarget">videos</property>
             <property name="widgetAspect">SmallSquare</property>
             <property name="widgetSource">addon</property>
         </item>


### PR DESCRIPTION
## Summary
- The default "Video-Addons" widget entry (Add-ons menu) had `widgetType`/`widgetTarget` set to `programs` instead of `video`/`videos`, apparently copy-pasted from the neighboring "Programs-Addons" entry.
- This caused video add-ons opened from that widget to run inside the Programs window instead of the Videos window, breaking `Select` on playable (non-folder) items — folders navigated fine, but selecting an actual file did nothing.
- Fixed to `widgetType: video`, `widgetTarget: videos`, matching the convention used by the other video widgets (`Random-Movies`, `Random-TVShows`).

## Test plan
- [x] Confirmed via JSON-RPC (`GUI.GetProperties`) that a video add-on opened through this widget now runs in the Videos window (id 10025) instead of Programs (id 10001), and that `Select` on a playable item works again.